### PR TITLE
Feat: rule monitor_gce_service_account

### DIFF
--- a/services/monitor/instances/monitor_gce_instance_service_account/constraints/no_default_service_account/constraint.yaml
+++ b/services/monitor/instances/monitor_gce_instance_service_account/constraints/no_default_service_account/constraint.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 apiVersion: constraints.gatekeeper.sh/v1alpha1
 kind: GCPComputeServiceAccountConstraintV1
 metadata:

--- a/services/monitor/instances/monitor_gce_instance_service_account/constraints/no_default_service_account/constraint.yaml
+++ b/services/monitor/instances/monitor_gce_instance_service_account/constraints/no_default_service_account/constraint.yaml
@@ -19,7 +19,6 @@ metadata:
   annotations:
     description: GCE VMs cannot use default service account.
     category: Identity and Access Management
-    documentation: https://github.com/adeo/DataFactoryArchitecture/blob/master/Heimdall-Manual/components/gce_instance_service_account.md
 spec:
   severity: major
   match:

--- a/services/monitor/instances/monitor_gce_instance_service_account/constraints/no_default_service_account/constraint.yaml
+++ b/services/monitor/instances/monitor_gce_instance_service_account/constraints/no_default_service_account/constraint.yaml
@@ -1,0 +1,18 @@
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPComputeServiceAccountConstraintV1
+metadata:
+  name: no_default_service_account
+  annotations:
+    description: GCE VMs cannot use default service account.
+    category: Identity and Access Management
+    documentation: https://github.com/adeo/DataFactoryArchitecture/blob/master/Heimdall-Manual/components/gce_instance_service_account.md
+spec:
+  severity: major
+  match:
+    target: [organization/] # to_be_adapted
+    exclude:
+  parameters:
+    mode: "blacklist"
+    match_mode: "regex"
+    service_accounts: 
+      - "[0-9]*-compute@developer.gserviceaccount.com"

--- a/services/monitor/instances/monitor_gce_instance_service_account/constraints/no_default_service_account/readme.md
+++ b/services/monitor/instances/monitor_gce_instance_service_account/constraints/no_default_service_account/readme.md
@@ -1,0 +1,32 @@
+# clouddns_dnssec
+
+## Background
+
+GCE Instances use service accounts to run.
+
+Per default, an instance uses the service account {project_number}-compute@developer.gserviceaccount.com. This service account is the compute engine service account for the project, who by default has the Editor role on the project.
+This means that by default, every instance in the project runs with editor rights on the projects. Should an instance be compromized, malicious activity would have editor role : all data in the project could be accessible (data leak risk), new ressources could be created (financial risk) or illegal activity could be carried out (liability risk).
+
+## Fix
+
+```shell
+# Create a specfic service account for your instance
+gcloud iam service-accounts create SERVICE_ACCOUNT_ID --description="DESCRIPTION" --display-name="DISPLAY_NAME"
+# Grant only required roles to service accounts !!! Example with minimal rights !!!
+gcloud projects add-iam-policy-binding PROJECT_ID \
+    --member="serviceAccount:SERVICE_ACCOUNT_ID@PROJECT_ID.iam.gserviceaccount.com" \
+    --role="roles/monitoring.metricWriter"
+gcloud projects add-iam-policy-binding PROJECT_ID \
+    --member="serviceAccount:SERVICE_ACCOUNT_ID@PROJECT_ID.iam.gserviceaccount.com" \
+    --role="roles/logging.logWriter"
+# Update your instance to use the new service account
+gcloud compute instances set-service-account [INSTANCE_NAME] \
+   --service-account SERVICE_ACCOUNT_ID@PROJECT_ID.iam.gserviceaccount.com
+```
+
+## References
+
+- [Service Accounts guide for Compute Engine](https://cloud.google.com/compute/docs/access/service-accounts)
+- [Creating a service account](https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances#createanewserviceaccount)
+- [Granting access](https://cloud.google.com/iam/docs/granting-changing-revoking-access#granting_access_to_a_service_account_for_a_resource)
+- [Changing the service account for a running instance](https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances#changeserviceaccountandscopes)

--- a/services/monitor/instances/monitor_gce_instance_service_account/constraints/no_default_service_account/readme.md
+++ b/services/monitor/instances/monitor_gce_instance_service_account/constraints/no_default_service_account/readme.md
@@ -1,4 +1,4 @@
-# clouddns_dnssec
+# gce_instance_service_account no_default_service_account
 
 ## Background
 

--- a/services/monitor/instances/monitor_gce_instance_service_account/instance.yaml
+++ b/services/monitor/instances/monitor_gce_instance_service_account/instance.yaml
@@ -1,0 +1,2 @@
+gcf:
+  triggerTopic: cai-rces-compute-Instance

--- a/services/monitor/instances/monitor_gce_instance_service_account/instance.yaml
+++ b/services/monitor/instances/monitor_gce_instance_service_account/instance.yaml
@@ -1,2 +1,16 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 gcf:
   triggerTopic: cai-rces-compute-Instance

--- a/services/monitor/instances/monitor_gce_instance_service_account/monitor_gce_instance_service_account.rego
+++ b/services/monitor/instances/monitor_gce_instance_service_account/monitor_gce_instance_service_account.rego
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 package templates.gcp.GCPComputeServiceAccountConstraintV1
 
 import data.validator.gcp.lib as lib

--- a/services/monitor/instances/monitor_gce_instance_service_account/monitor_gce_instance_service_account.rego
+++ b/services/monitor/instances/monitor_gce_instance_service_account/monitor_gce_instance_service_account.rego
@@ -1,0 +1,67 @@
+package templates.gcp.GCPComputeServiceAccountConstraintV1
+
+import data.validator.gcp.lib as lib
+
+
+deny[{
+	"msg": message,
+	"details": metadata,
+}] {
+	constraint := input.constraint
+	lib.get_constraint_params(constraint, params)
+
+	
+	mode := lib.get_default(params, "mode", "whitelist")
+	match_mode := lib.get_default(params, "match_mode", "exact")
+	accounts_filter := lib.get_default(params, "service_accounts", [])
+
+	asset := input.asset
+	asset.asset_type == "compute.googleapis.com/Instance"
+
+	trace(sprintf("mode: %v, match_mode: %v, filter: %v", [mode, match_mode, accounts_filter[_]]))
+
+	name := asset.resource.data.name
+	serviceAccounts := asset.resource.data.serviceAccounts
+	emails := [ serviceAccounts[_].email]
+	trace(sprintf("asset_name:%v, sa_emails: %v", [name, emails]))
+		
+	sa_name_targeted(emails[_],accounts_filter,mode,match_mode)
+
+	message := sprintf("VM %v uses service account: %v.", [name, concat(", ", emails)])
+	metadata := {
+		"resource": asset.name
+		}
+}
+
+###########################
+# Rule Utilities
+###########################
+sa_name_targeted(sa_email, accounts_filter, mode, match_mode) {
+	mode == "whitelist"
+	match_mode == "exact"
+	matches := {sa_email} & cast_set(accounts_filter)
+	count(matches) == 0
+}
+
+sa_name_targeted(sa_email, accounts_filter, mode, match_mode) {
+	mode == "blacklist"
+	match_mode == "exact"
+	matches := {sa_email} & cast_set(accounts_filter)
+	count(matches) > 0
+}
+
+sa_name_targeted(sa_email, accounts_filter, mode, match_mode) {
+	mode == "whitelist"
+	match_mode == "regex"
+	not re_match_name(sa_email, accounts_filter)
+}
+
+sa_name_targeted(sa_email, accounts_filter, mode, match_mode) {
+	mode == "blacklist"
+	match_mode == "regex"
+	re_match_name(sa_email, accounts_filter)
+}
+
+re_match_name(name, filters) {
+	re_match(filters[_], name)
+}


### PR DESCRIPTION
fixes #64 

New rule to check service accounts used on GCE instance.
Rule supports blacklist / whitelist mode
Matches on service_account emails, either with exact match or regex pattern.