### PR TITLE
feat: rule monitor_gcf_env_secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ram-config-template
 
 Real-time Asset Monitor configuration template to be cloned and adapted to your environment.  
-[Product overview](docs/product_overview.md)
+[Product overview.](docs/product_overview.md)
 
 ## Customize compliance rules
 

--- a/services/monitor/instances/monitor_gcf_env_secrets/constraints/no_secrets_in_env_vars/constraint.yaml
+++ b/services/monitor/instances/monitor_gcf_env_secrets/constraints/no_secrets_in_env_vars/constraint.yaml
@@ -1,0 +1,171 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPCloudfunctionEnvSecretConstraintV1
+metadata:
+  name: no_secrets_in_env_vars
+  annotations:
+    description: CloudFunction with ENV var containing suspicious keywords.
+    category: Secret Management
+spec:
+  severity: critical
+  match:
+    target: ["organization/"] # to_be_adapted 
+  parameters:
+    name_whitelist:
+      - GOOGLE_CREDENTIALS_PATH
+      - CONNECT_INTERNAL_KEY_CONVERTER
+      - CONNECT_KEY_CONVERTER
+      - CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE
+    name_contains:
+      - "SECRET"
+      - "PASS"
+      - "CREDENTIAL"
+      - "TOKEN"
+      - "KEY"
+      - "PWD"
+    value_contains:
+      -
+          regex: '(A3T[A-Z0-9]|AKIA|AGPA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'
+          type: 'AWS Access Key ID Value'
+      -
+          regex: '((\"|''|`)?((?i)aws)?_?((?i)access)_?((?i)key)?_?((?i)id)?(\"|''|`)?\\s{0,50}(:|=>|=)\\s{0,50}(\"|''|`)?(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}(\"|''|`)?)'
+          type: 'AWS Access Key ID'
+      -
+          regex: '((\"|''|`)?((?i)aws)?_?((?i)account)_?((?i)id)?(\"|''|`)?\\s{0,50}(:|=>|=)\\s{0,50}(\"|''|`)?[0-9]{4}-?[0-9]{4}-?[0-9]{4}(\"|''|`)?)'
+          type: 'AWS Account ID'
+      -
+          regex: '((\"|''|`)?((?i)aws)?_?((?i)secret)_?((?i)access)?_?((?i)key)?_?((?i)id)?(\"|''|`)?\\s{0,50}(:|=>|=)\\s{0,50}(\"|''|`)?[A-Za-z0-9/+=]{40}(\"|''|`)?)'
+          type: 'AWS Secret Access Key'
+      -
+          regex: '((\"|''|`)?((?i)aws)?_?((?i)session)?_?((?i)token)?(\"|''|`)?\\s{0,50}(:|=>|=)\\s{0,50}(\"|''|`)?[A-Za-z0-9/+=]{16,}(\"|''|`)?)'
+          type: 'AWS Session Token'
+      -
+          regex: '(?i)artifactory.{0,50}(\"|''|`)?[a-zA-Z0-9=]{112}(\"|''|`)?'
+          type: Artifactory
+      -
+          regex: '(?i)codeclima.{0,50}(\"|''|`)?[0-9a-f]{64}(\"|''|`)?'
+          type: CodeClimate
+      -
+          regex: 'EAACEdEose0cBA[0-9A-Za-z]+'
+          type: 'Facebook access token'
+      -
+          regex: '((\"|''|`)?type(\"|''|`)?\\s{0,50}(:|=>|=)\\s{0,50}(\"|''|`)?service_account(\"|''|`)?,?)'
+          type: 'Google (GCM) Service account'
+      -
+          regex: '(?:r|s)k_[live|test]_[0-9a-zA-Z]{24}'
+          type: 'Stripe API key'
+      -
+          regex: '[0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
+          type: 'Google OAuth Key'
+      -
+          regex: 'AIza[0-9A-Za-z\\-_]{35}'
+          type: 'Google Cloud API Key'
+      -
+          regex: 'ya29\\.[0-9A-Za-z\\-_]+'
+          type: 'Google OAuth Access Token'
+      -
+          regex: 'sk_[live|test]_[0-9a-z]{32}'
+          type: 'Picatic API key'
+      -
+          regex: 'sq0atp-[0-9A-Za-z\-_]{22}'
+          type: 'Square Access Token'
+      -
+          regex: 'sq0csp-[0-9A-Za-z\-_]{43}'
+          type: 'Square OAuth Secret'
+      -
+          regex: 'access_token\$production\$[0-9a-z]{16}\$[0-9a-f]{32}'
+          type: 'PayPal/Braintree Access Token'
+      -
+          regex: 'amzn\.mws\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+          type: 'Amazon MWS Auth Token'
+      -
+          regex: 'SK[0-9a-fA-F]{32}'
+          type: 'Twilo API Key'
+      -
+          regex: 'SG\.[0-9A-Za-z\-_]{22}\.[0-9A-Za-z\-_]{43}'
+          type: 'SendGrid API Key'
+      -
+          regex: 'key-[0-9a-zA-Z]{32}'
+          type: 'MailGun API Key'
+      -
+          regex: '[0-9a-f]{32}-us[0-9]{12}'
+          type: 'MailChimp API Key'
+      -
+          regex: 'sshpass -p.*[''|\"]'
+          type: 'SSH Password'
+      -
+          regex: '(https\\://outlook\\.office.com/webhook/[0-9a-f-]{36}\\@)'
+          type: 'Outlook team'
+      -
+          regex: '(?i)sauce.{0,50}(\"|''|`)?[0-9a-f-]{36}(\"|''|`)?'
+          type: 'Sauce Token'
+      -
+          regex: '(xox[pboa]-[0-9]{12}-[0-9]{12}-[A-Za-z0-9]{24})'
+          type: 'Slack Token'
+      -
+          regex: '(xox[pboa]-[0-9]{12}-[0-9]{12}-[0-9]{12}-[a-z0-9]{32})'
+          type: 'Slack Token'
+      -
+          regex: 'https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}'
+          type: 'Slack Webhook'
+      -
+          regex: '(?i)sonar.{0,50}(\"|''|`)?[0-9a-f]{40}(\"|''|`)?'
+          type: 'SonarQube Docs API Key'
+      -
+          regex: '(?i)hockey.{0,50}(\"|''|`)?[0-9a-f]{32}(\"|''|`)?'
+          type: HockeyApp
+      -
+          regex: '([\w+]{1,24})(://)([^$<]{1})([^\s";]{1,}):([^$<]{1})([^\s";/]{1,})@[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,24}([^\s]+)'
+          type: 'Username and password in URI'
+      -
+          regex: 'oy2[a-z0-9]{43}'
+          type: 'NuGet API Key'
+      -
+          regex: 'hawk\.[0-9A-Za-z\-_]{20}\.[0-9A-Za-z\-_]{20}'
+          type: 'StackHawk API Key'
+      -
+          regex: '-----BEGIN (EC |RSA |DSA |OPENSSH |PGP |)PRIVATE KEY'
+          type: 'Contains a private key'
+      -
+          regex: 'define(.{0,20})?(DB_CHARSET|NONCE_SALT|LOGGED_IN_SALT|AUTH_SALT|NONCE_KEY|DB_HOST|DB_PASSWORD|AUTH_KEY|SECURE_AUTH_KEY|LOGGED_IN_KEY|DB_NAME|DB_USER)(.{0,20})?[''|"].{10,120}[''|"]'
+          type: WP-Config
+      -
+          regex: '(?i)(aws_access_key_id|aws_secret_access_key)(.{0,20})?=.[0-9a-zA-Z\/+]{20,40}'
+          type: 'AWS cred file info'
+      -
+          regex: '(?i)(facebook|fb)(.{0,20})?(?-i)[''\"][0-9a-f]{32}[''\"]'
+          type: 'Facebook Secret Key'
+      -
+          regex: '(?i)(facebook|fb)(.{0,20})?[''\"][0-9]{13,17}[''\"]'
+          type: 'Facebook Client ID'
+      -
+          regex: '(?i)twitter(.{0,20})?[''\"][0-9a-z]{35,44}[''\"]'
+          type: 'Twitter Secret Key'
+      -
+          regex: '(?i)twitter(.{0,20})?[''\"][0-9a-z]{18,25}[''\"]'
+          type: 'Twitter Client ID'
+      -
+          regex: '(?i)github(.{0,20})?(?-i)[''\"][0-9a-zA-Z]{35,40}[''\"]'
+          type: 'Github Key'
+      -
+          regex: '(?i)heroku(.{0,20})?[''"][0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}[''"]'
+          type: 'Heroku API key'
+      -
+          regex: '(?i)linkedin(.{0,20})?(?-i)[''\"][0-9a-z]{12}[''\"]'
+          type: 'Linkedin Client ID'
+      -
+          regex: '(?i)linkedin(.{0,20})?[''\"][0-9a-z]{16}[''\"]'
+          type: 'LinkedIn Secret Key'

--- a/services/monitor/instances/monitor_gcf_env_secrets/constraints/no_secrets_in_env_vars/constraint.yaml
+++ b/services/monitor/instances/monitor_gcf_env_secrets/constraints/no_secrets_in_env_vars/constraint.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   severity: critical
   match:
-    target: ["organization/"] # to_be_adapted 
+    target: [organization/] # to_be_adapted 
   parameters:
     name_whitelist:
       - GOOGLE_CREDENTIALS_PATH

--- a/services/monitor/instances/monitor_gcf_env_secrets/constraints/no_secrets_in_env_vars/readme.md
+++ b/services/monitor/instances/monitor_gcf_env_secrets/constraints/no_secrets_in_env_vars/readme.md
@@ -1,0 +1,16 @@
+# gcf_env_secrets no_secret_in_env_vars
+
+## Background
+
+Google CloudFunctions can use environment variables.
+These variables are not secret, and can be accessed in multiple way.
+Sensitive information should not be avaible in function source code, but stored securily and accessed when required.
+
+## Fix
+
+Use Google Secret Manager to store sensitive information and use code in your function to acces it. Secret Manager Client libraries exist for all GCF runtime environment.
+
+## References
+
+- [Cloud Secret Manager](https://cloud.google.com/secret-manager/docs)
+- [Using Secret Manager Client library](https://cloud.google.com/secret-manager/docs/reference/libraries#using_the_client_library)

--- a/services/monitor/instances/monitor_gcf_env_secrets/instance.yaml
+++ b/services/monitor/instances/monitor_gcf_env_secrets/instance.yaml
@@ -1,0 +1,16 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+gcf:
+  triggerTopic: cai-rces-cloudfunctions-CloudFunction

--- a/services/monitor/instances/monitor_gcf_env_secrets/monitor_gcf_env_secrets.rego
+++ b/services/monitor/instances/monitor_gcf_env_secrets/monitor_gcf_env_secrets.rego
@@ -37,7 +37,7 @@ deny[{
 	env_vars_not_wl := { e:env_vars[e] | not is_whitelisted(e,name_whitelist)}
 	# trace(sprintf("env_vars not whitelisted: %v", [env_vars_not_wl]))
 
-	name_matches_found := [e |  env_vars_not_wl[e] ; contains(e,envname_contains[_])]
+	name_matches_found := [e |  env_vars_not_wl[e] ; contains(lower(e),lower(envname_contains[_]))]
 	# trace(sprintf("name_matches_found: %v", [name_matches_found]))
 	
 	value_matches_found := [sprintf("%v (reason: %v)", [e,envvalue_contains[v].type]) |  {env_vars[e],envvalue_contains[v]} ; re_match(envvalue_contains[v].regex,env_vars[e])]

--- a/services/monitor/instances/monitor_gcf_env_secrets/monitor_gcf_env_secrets.rego
+++ b/services/monitor/instances/monitor_gcf_env_secrets/monitor_gcf_env_secrets.rego
@@ -1,0 +1,69 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+package templates.gcp.GCPCloudfunctionEnvSecretConstraintV1
+
+import data.validator.gcp.lib as lib
+
+deny[{
+	"msg": message,
+	"details": metadata,
+}] {
+	constraint := input.constraint
+	lib.get_constraint_params(constraint, params)
+
+	name_whitelist := lib.get_default(params, "name_whitelist", [])
+	envname_contains := lib.get_default(params, "name_contains", [])
+	envvalue_contains := lib.get_default(params, "value_contains", [])
+
+
+	asset := input.asset
+	asset.asset_type == "cloudfunctions.googleapis.com/CloudFunction"
+
+	env_vars := lib.get_default(asset.resource.data, "environmentVariables", {})
+	# trace(sprintf("env_vars: %v", [env_vars]))
+
+	env_vars_not_wl := { e:env_vars[e] | not is_whitelisted(e,name_whitelist)}
+	# trace(sprintf("env_vars not whitelisted: %v", [env_vars_not_wl]))
+
+	name_matches_found := [e |  env_vars_not_wl[e] ; contains(e,envname_contains[_])]
+	# trace(sprintf("name_matches_found: %v", [name_matches_found]))
+	
+	value_matches_found := [sprintf("%v (reason: %v)", [e,envvalue_contains[v].type]) |  {env_vars[e],envvalue_contains[v]} ; re_match(envvalue_contains[v].regex,env_vars[e])]
+	# trace(sprintf("value_matches_found: %v", [value_matches_found]))
+
+	base64_encoded_env_vars := { e: base64.decode(env_vars[e]) | is_base64(env_vars[e]) }
+	# trace(sprintf("base64_encoded_env_vars: %v", [base64_encoded_env_vars]))
+	
+	value_matches_found_base64 := [sprintf("%v (reason: %v, base64 encoded)", [e,envvalue_contains[v].type]) |  {base64_encoded_env_vars[e],envvalue_contains[v]} ; re_match(envvalue_contains[v].regex,base64_encoded_env_vars[e])]
+	# trace(sprintf("value_matches_found_base64: %v", [value_matches_found_base64]))
+
+	all_value_matches_found := array.concat(value_matches_found,value_matches_found_base64)
+	# trace(sprintf("all_value_matches_found: %v", [all_value_matches_found]))
+	
+	count(name_matches_found)+count(all_value_matches_found) > 0
+
+	message := sprintf("CloudFunction %v has env vars with suspicious name: [%v], with suspicious value: [%v].", [asset.resource.data.name, concat(", ",name_matches_found), concat(", ",all_value_matches_found)])
+	metadata := {"resource": asset.name}
+}
+
+
+is_base64(string) {
+	pattern := "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
+	re_match(pattern,string) 
+}
+
+is_whitelisted(name, name_whitelist) {
+	name =  name_whitelist[_]
+}

--- a/solution.yaml
+++ b/solution.yaml
@@ -93,6 +93,7 @@ monitoring:
       - bigtableadmin.googleapis.com/Instance
       - bigtableadmin.googleapis.com/Table
       - cloudbilling.googleapis.com/BillingAccount
+      - cloudfunctions.googleapis.com/CloudFunction
       - cloudkms.googleapis.com/CryptoKey
       - cloudkms.googleapis.com/CryptoKeyVersion
       - cloudkms.googleapis.com/KeyRing
@@ -170,6 +171,7 @@ monitoring:
       - appengine.googleapis.com/Service
       - bigquery.googleapis.com/Dataset
       - bigtableadmin.googleapis.com/Instance
+      - cloudfunctions.googleapis.com/CloudFunction
       - cloudkms.googleapis.com/CryptoKey
       - cloudresourcemanager.googleapis.com/Folder
       - cloudresourcemanager.googleapis.com/Organization


### PR DESCRIPTION
fixes #66 

New rules to check environment variables on GCF.

Rule triggers if :
- var name contains keywords
- var value matches regex known patterns (even if value is base64 encoded)

Rule also allows var name whitelisting.