### PR TITLE
feat: new rule monitor_gci_group_members

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ram-config-template
 
 Real-time Asset Monitor configuration template to be cloned and adapted to your environment.  
-[Product overview](docs/product_overview.md)
+[Product overview.](docs/product_overview.md)
 
 ## Customize compliance rules
 

--- a/services/monitor/instances/monitor_gci_group_members/constraints/external_members_denied/constraint.yaml
+++ b/services/monitor/instances/monitor_gci_group_members/constraints/external_members_denied/constraint.yaml
@@ -17,9 +17,8 @@ kind: CIGroupMembersConstraintV1
 metadata:
   name: external_members_denied
   annotations:
-    description: Members must be from ADEO domains only
+    description: Members must be from owned domains only
     category: Identity and Access Management
-    documentation: https://github.com/adeo/DataFactoryArchitecture/blob/master/Heimdall-Manual/components/gci_group_members.md
 spec:
   severity: major
   match:
@@ -35,3 +34,5 @@ spec:
     - "**@**.gserviceaccount.com" # service accounts are OK
     - "**@example.domain.com"
     - "**@anotherdomain.org"
+    # - "**@mydomainone.com"
+    # - "**@mydomaintwo.com"

--- a/services/monitor/instances/monitor_gci_group_members/constraints/external_members_denied/constraint.yaml
+++ b/services/monitor/instances/monitor_gci_group_members/constraints/external_members_denied/constraint.yaml
@@ -1,0 +1,37 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: CIGroupMembersConstraintV1
+metadata:
+  name: external_members_denied
+  annotations:
+    description: Members must be from ADEO domains only
+    category: Identity and Access Management
+    documentation: https://github.com/adeo/DataFactoryArchitecture/blob/master/Heimdall-Manual/components/gci_group_members.md
+spec:
+  severity: major
+  match:
+    target: [directories/]
+    exclude:
+  parameters:
+    mode: whitelist
+    selector:
+      email:  # GLOB, with . and @ as separators
+        - '**'
+    exemptions: [""] # on member email, not group email or asset.name
+    members:
+    - "**@**.gserviceaccount.com" # service accounts are OK
+    - "**@example.domain.com"
+    - "**@anotherdomain.org"

--- a/services/monitor/instances/monitor_gci_group_members/constraints/external_members_denied/readme.md
+++ b/services/monitor/instances/monitor_gci_group_members/constraints/external_members_denied/readme.md
@@ -1,0 +1,16 @@
+# gci_group_members external_members_denied
+
+## Background
+
+CloudIdentity groups should not have members with email addresses in external domains.
+
+## Fix
+
+[Remove forbidden members of affected groups with Admin console](https://admin.google.com/)
+[Remove forbidden members of affected groups with Google Groups](https://groups.google.com/)
+
+## References
+
+- [Cloud Identity Documentation](https://cloud.google.com/identity/docs)
+- [Admin console](https://admin.google.com/)
+- [Google Groups](https://groups.google.com/)

--- a/services/monitor/instances/monitor_gci_group_members/instance.yaml
+++ b/services/monitor/instances/monitor_gci_group_members/instance.yaml
@@ -1,0 +1,16 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+gcf:
+  triggerTopic: gci-groupMembers

--- a/services/monitor/instances/monitor_gci_group_members/monitor_gci_group_members.rego
+++ b/services/monitor/instances/monitor_gci_group_members/monitor_gci_group_members.rego
@@ -1,0 +1,69 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+package templates.gcp.CIGroupMembersConstraintV1
+
+import data.validator.gcp.lib as lib
+
+deny[{
+    "msg": message,
+    "details": metadata,
+}] {
+    constraint := input.constraint
+	lib.get_constraint_params(constraint, params)
+    mode := lib.get_default(params, "mode", "whitelist")
+    # trace(sprintf("Param mode : %v", [mode]))
+	target_match_count(mode, desired_count)
+
+    members := lib.get_default(params, "members", ["**"] )
+    # trace(sprintf("Param members : %v", [members]))
+
+    asset := input.asset
+    # trace(sprintf("Param asset : %v", [asset]))
+
+    asset.asset_type == "www.googleapis.com/admin/directory/members"
+
+    groupEmailMatching := lib.get_default(params.selector, "email", ["**"] )
+    # trace(sprintf("groupEmailMatching : %v", [groupEmailMatching]))
+    
+    groupMember := asset.resource
+    groupEmail := groupMember.groupEmail
+    type_set := {"USER", "GROUP"}
+    type_set[groupMember.type]
+    glob.match(groupEmailMatching[_] , [".","@"], groupEmail)
+    memberEmail := groupMember.memberEmail
+    # trace(sprintf("Param memberEmail : %v", [memberEmail]))
+
+
+    # Check if resource is in exempt list
+	exempt_list := lib.get_default(params, "exemptions", [])
+	matches := {memberEmail} & cast_set(exempt_list)
+	count(matches) == 0
+    
+    matches_found := [r | r = members[_]; glob.match(r, [".","@"], memberEmail)]
+	trace(sprintf("Param matches_found : %v", [matches_found]))
+
+    count(matches_found) != desired_count    
+        
+    message := sprintf("Member %v for group %v is not authorized.", [memberEmail, groupEmail])
+    metadata := {"resource": asset.name}
+}
+
+target_match_count(mode) = 0 {
+	mode == "blacklist"
+}
+
+target_match_count(mode) = 1 {
+	mode == "whitelist"
+}


### PR DESCRIPTION
fixes #62 

New rule to check group members
feature : 
 - group selector on group email (to choose on which group the rule apply
 - blacklist/whitelist mode on group membership (ie: allow only some member's email patterns, or deny some patterns)
 - exemptions list for members (email) 